### PR TITLE
refactor(lib): Improve NixOS option definitions

### DIFF
--- a/modules/home/firefox.nix
+++ b/modules/home/firefox.nix
@@ -5,40 +5,17 @@
       cfg = config.programs.firefox.betterfox;
     in
     {
-      config = lib.mkIf cfg.enable {
-        assertions = [
-          {
-            assertion = builtins.all (
-              profile:
-              let
-                smoothfoxEnabledSections = builtins.filter (section: profile.settings.smoothfox.${section}.enable) (
-                  builtins.attrNames profile.settings.smoothfox
-                );
-              in
-              builtins.length smoothfoxEnabledSections <= 1
-            ) (builtins.attrValues cfg.profiles);
-            message = "Only one smoothfox section can be enabled at a time across all profiles.";
-          }
-        ];
-
-        programs.firefox.profiles = builtins.mapAttrs (_name: profile: {
-          settings = profile.flatSettings;
-        }) cfg.profiles;
-      };
-
       options.programs.firefox.betterfox = {
         enable = lib.mkEnableOption "betterfox support in profiles";
 
         version = lib.mkOption {
-          default = "main";
-          description = "The version of betterfox user.js used";
-          example = "142.0";
           type = lib.types.enum (builtins.attrNames (import ../../data/firefox));
+          default = "main";
+          example = "142.0";
+          description = "The version of betterfox user.js used.";
         };
 
         profiles = lib.mkOption {
-          default = { };
-          description = "Configurations for each profile";
           type = lib.types.attrsOf (
             lib.types.submodule (
               { config, ... }:
@@ -65,19 +42,17 @@
                 ) data;
 
                 options = {
-                  enable = lib.mkOption {
+                  enable = lib.mkEnableOption "betterfox for this profile" // {
                     default = builtins.any (x: x.enable) (builtins.attrValues config.settings);
-                    defaultText = "`true` when `settings` has any section enabled";
-                    description = "Whether to enable betterfox for this profile";
-                    example = false;
+                    defaultText = "`true` when `settings` has any section enabled.";
                   };
 
                   enableAllSections = lib.mkEnableOption "all sections by default";
 
                   flatSettings = lib.mkOption {
-                    description = "All preferences";
-                    readOnly = true;
                     type = lib.types.attrsOf lib.types.anything;
+                    description = "All preferences.";
+                    readOnly = true;
                   };
 
                   settings =
@@ -92,7 +67,31 @@
               }
             )
           );
+
+          default = { };
+          description = "Configurations for each profile";
         };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = builtins.all (
+              profile:
+              let
+                smoothfoxEnabledSections = builtins.filter (section: profile.settings.smoothfox.${section}.enable) (
+                  builtins.attrNames profile.settings.smoothfox
+                );
+              in
+              builtins.length smoothfoxEnabledSections <= 1
+            ) (builtins.attrValues cfg.profiles);
+            message = "Only one smoothfox section can be enabled at a time across all profiles.";
+          }
+        ];
+
+        programs.firefox.profiles = builtins.mapAttrs (_name: profile: {
+          settings = profile.flatSettings;
+        }) cfg.profiles;
       };
     };
 }

--- a/modules/home/lib/_pref-option.nix
+++ b/modules/home/lib/_pref-option.nix
@@ -7,8 +7,8 @@ pref: {
       prefType = import ./_pref-type.nix { inherit lib; };
     in
     lib.mkOption {
-      default = { };
-      description = "${pref.name} preference";
       type = prefType pref;
+      default = { };
+      description = "${pref.name} preference.";
     };
 }

--- a/modules/home/lib/_pref-type.nix
+++ b/modules/home/lib/_pref-type.nix
@@ -3,25 +3,23 @@ pref:
 lib.types.submodule (
   { config, ... }:
   {
-    config.flat = lib.optionalAttrs config.enable { ${pref.name} = config.value; };
-
     options = {
-      enable = lib.mkOption {
+      enable = lib.mkEnableOption "${pref.name} preference" // {
         default = pref.enabled;
-        description = "Whether to enable ${pref.name} preference";
-        type = lib.types.bool;
       };
 
       flat = lib.mkOption {
-        readOnly = true;
         type = lib.types.attrsOf lib.types.anything;
+        readOnly = true;
       };
 
       value = lib.mkOption {
-        default = pref.value;
-        description = "Value of ${pref.name} preference";
         type = lib.types.anything;
+        default = pref.value;
+        description = "Value of ${pref.name} preference.";
       };
     };
+
+    config.flat = lib.optionalAttrs config.enable { ${pref.name} = config.value; };
   }
 )

--- a/modules/home/lib/_section-option.nix
+++ b/modules/home/lib/_section-option.nix
@@ -4,7 +4,7 @@ let
   sectionType = import ./_section-type.nix { inherit lib; };
 in
 lib.mkOption {
-  default = { };
-  description = "${name}: ${section.meta.title}";
   type = sectionType name section;
+  default = { };
+  description = "${name}: ${section.meta.title}.";
 }

--- a/modules/home/lib/_section-type.nix
+++ b/modules/home/lib/_section-type.nix
@@ -6,30 +6,25 @@ in
 lib.types.submodule (
   { config, ... }:
   {
-    config.flatSettings = lib.optionalAttrs config.enable (
-      builtins.foldl' (x: y: lib.recursiveUpdate x y) { } (
-        lib.mapAttrsToList (name: _: config.${name}.flatSettings) subsections
-      )
-    );
-
     options =
       let
         subsectionOption = import ./_subsection-option.nix { inherit lib; };
       in
       {
-        enable = lib.mkOption {
-          default = false;
-          description = "Whether to enable preferences for ${name}";
-          example = false;
-          type = lib.types.bool;
-        };
+        enable = lib.mkEnableOption "preferences for ${name}";
 
         flatSettings = lib.mkOption {
-          description = "All enabled preferences in ${name} section";
-          readOnly = true;
           type = lib.types.attrsOf lib.types.anything;
+          description = "All enabled preferences in ${name} section.";
+          readOnly = true;
         };
       }
       // builtins.mapAttrs subsectionOption subsections;
+
+    config.flatSettings = lib.optionalAttrs config.enable (
+      builtins.foldl' (x: y: lib.recursiveUpdate x y) { } (
+        lib.mapAttrsToList (name: _: config.${name}.flatSettings) subsections
+      )
+    );
   }
 )

--- a/modules/home/lib/_subsection-option.nix
+++ b/modules/home/lib/_subsection-option.nix
@@ -4,7 +4,7 @@ let
   subsectionType = import ./_subsection-type.nix { inherit lib; };
 in
 lib.mkOption {
-  default = { };
-  description = "${name}: ${subsection.meta.title}";
   type = subsectionType name subsection;
+  default = { };
+  description = "${name}: ${subsection.meta.title}.";
 }

--- a/modules/home/lib/_subsection-type.nix
+++ b/modules/home/lib/_subsection-type.nix
@@ -3,30 +3,27 @@ name: subsection:
 lib.types.submodule (
   { config, ... }:
   {
-    config.flatSettings = lib.optionalAttrs config.enable (
-      builtins.foldl' (x: y: lib.recursiveUpdate x y) { } (
-        map (pref: config.${pref.name}.flat) subsection.settings
-      )
-    );
-
     options =
       let
         prefOption = import ./_pref-option.nix { inherit lib; };
       in
       {
-        enable = lib.mkOption {
+        enable = lib.mkEnableOption "preferences for ${name}" // {
           default = true;
-          description = "Whether to enable preferences for ${name}";
-          example = false;
-          type = lib.types.bool;
         };
 
         flatSettings = lib.mkOption {
-          description = "All enabled preferences in ${name} subsection";
-          readOnly = true;
           type = lib.types.attrsOf lib.types.anything;
+          description = "All enabled preferences in ${name} subsection.";
+          readOnly = true;
         };
       }
       // builtins.listToAttrs (map prefOption subsection.settings);
+
+    config.flatSettings = lib.optionalAttrs config.enable (
+      builtins.foldl' (x: y: lib.recursiveUpdate x y) { } (
+        map (pref: config.${pref.name}.flat) subsection.settings
+      )
+    );
   }
 )


### PR DESCRIPTION
This commit refactors the NixOS option definitions to improve their readability and maintainability.

The following changes were made:

- Replaced `lib.mkOption` with `lib.mkEnableOption` where appropriate to simplify the option definitions.
- Standardized the option descriptions by ensuring they end with a period.
- Reordered code blocks within the option definitions to follow a consistent structure.