### PR TITLE
Comment out Fastfox in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Below is an example of how to integrate Betterfox with Firefox using this module
 
         settings = {
           # To enable/disable specific sections
-          fastfox.enable = true;
+          # Note that Fasfox has been retired as of v148.0 (https://github.com/yokoffing/Betterfox/releases/tag/148.0)
+          # fastfox.enable = true;
 
           # To enable/disable specific subsections
           peskyfox = {


### PR DESCRIPTION
Ciao @HeitorAugustoLN

After updating my system I noticed that my configuration was not working anymore because of the missing `fastfox.enable` option. I found out that it has been removed upstream but the README file here still referenced it.

I added a comment to note that the option is not available on more recent versions of Betterfox, but left the block in as an example of enabling a whole section, like you had it initially.